### PR TITLE
Remove explicit handlebars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "hanachin <hanachin@gmail.com>",
     "Petr Bela <github@petrbela.com>"
   ],
-  "dependencies": {
-    "handlebars": "1.0.12"
-  },
   "peerDependencies": {
     "karma": ">=0.9"
   },


### PR DESCRIPTION
I'm really not sure how to solve this correctly, but what I'm trying to do is run tests against Handlebars 3.0, since that's what I run in production. Removing the explicit dependency on handlebars==1.0.12 here allows us to use whichever version of handlebars we already have installed; in my case, 3.0.
