### PR TITLE
Export handlebars templates as AMD module

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,19 @@ var createHandlebarsPreprocessor = function(args, config, logger) {
 
     var template = templateName(file.originalPath);
 
-    try {
-      processed = "(function() {" + templates + " = " + templates + " || {};" +
-        templates + "['" + template + "'] = Handlebars.template(" +
-        handlebars.precompile(content) + ");})();";
-    } catch (e) {
-      log.error('%s\n  at %s', e.message, file.originalPath);
+    if(config.amd) {
+      processed = "define(['handlebars'], function(Handlebars) {\n" +
+                  "    return Handlebars.template(" + handlebars.precompile(content)  + ");\n" +
+                  "});"
+
+    } else {
+      try {
+        processed = "(function() {" + templates + " = " + templates + " || {};" +
+            templates + "['" + template + "'] = Handlebars.template(" +
+            handlebars.precompile(content) + ");})();";
+      } catch (e) {
+        log.error('%s\n  at %s', e.message, file.originalPath);
+      }
     }
 
     done(processed);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "Petr Bela <github@petrbela.com>"
   ],
   "dependencies": {
-    "handlebars": "*"
+    "handlebars": "1.3.0"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
If a config option of `amd` is set to `true`, then the compiled template is wrapped in an anonymous AMD module definition.

```
        handlebarsPreprocessor: {
            amd: true
        },
```
