### PR TITLE
AMD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ module.exports = function(config) {
 };
 ```
 
+### AMD Based Template Configuration
+
+If you want to export your compiled templates as anonymous AMD modules,
+use the `amd` option in the config as shown below:
+
+```js
+    handlebarsPreprocessor: {
+      amd: true
+    }
+```
+
 ## License
 
 MIT License

--- a/index.js
+++ b/index.js
@@ -29,12 +29,19 @@ var createHandlebarsPreprocessor = function(args, config, logger) {
 
     var template = templateName(file.originalPath);
 
-    try {
-      processed = "(function() {" + templates + " = " + templates + " || {};" +
-        templates + "['" + template + "'] = Handlebars.template(" +
-        handlebars.precompile(content) + ");})();";
-    } catch (e) {
-      log.error('%s\n  at %s', e.message, file.originalPath);
+    if(config.amd) {
+      processed = "define(['handlebars'], function(Handlebars) {\n" +
+                  "    return Handlebars.template(" + handlebars.precompile(content)  + ");\n" +
+                  "});";
+
+    } else {
+      try {
+        processed = "(function() {" + templates + " = " + templates + " || {};" +
+            templates + "['" + template + "'] = Handlebars.template(" +
+            handlebars.precompile(content) + ");})();";
+      } catch (e) {
+        log.error('%s\n  at %s', e.message, file.originalPath);
+      }
     }
 
     done(processed);

--- a/test/indexSpec.coffee
+++ b/test/indexSpec.coffee
@@ -54,3 +54,14 @@ describe 'preprocessor:handlebars', ->
 
       preprocessor('', file, done)
       expect(file.path).to.eq('filename.jsx')
+
+    it 'should generate an anonymous amd module', ->
+      preprocessor = factory({}, {amd: true}, logger, {})
+
+      done = (result) ->
+        expect(result).to.include("define(['handlebars'], function(Handlebars) {")
+        expect(result).to.include("});")
+      file = {originalPath: 'folder/file.hbs'}
+
+      preprocessor('', file, done)
+      expect(file.path).to.eq('folder/file.js')


### PR DESCRIPTION
Wraps compiled handlebars template in an anonymous AMD module given
an `amd:true` config option:

```
  handlebarsPreprocessor: {
    amd: true
  }
```

The processed file will be defined as follows:

```
  define(['handlebars'], function(Handlebars) {
    return Handlebars.template( ... COMPILED TEMPLATE ... );
  });
```

As you can see, the handlebars module must be named `'handlebars'`.
